### PR TITLE
Fixed test_net_listen_ready test. Fix #2

### DIFF
--- a/src/lib/irc.c
+++ b/src/lib/irc.c
@@ -131,6 +131,7 @@ void irc_listen() {
                 /* The shutdown flag should have been set by
                  * the signal handler, but it is safe to set it again. */
                 shutdown_requested = 1;
+                cleanup_bindings();
                 break;
             case NET_READY:
                 net_recv(msg);

--- a/src/lib/network.c
+++ b/src/lib/network.c
@@ -123,6 +123,7 @@ enum net_status net_listen() {
      * if the error is an interrupt signal. We'll just
      * ignore it since we are handling the signals. */
     if (read < 0) {
+        debug(("network: Select returned %d\n", errno));
         ret = (errno == EINTR)? NET_CLOSE : NET_ERROR;
     } else if (read > 0 && FD_ISSET(_socket, &read_fd_set)) {
         ret = NET_READY;


### PR DESCRIPTION
Fixed test_net_listen_ready test and removed test_listen_close test since signals cause the process to finish instead of waiting for select to return a value.
